### PR TITLE
Update pip version when running pep8 on tempet_neutron_plugin project

### DIFF
--- a/infraform/scenarios/podman/pep8-tests.ifr.j2
+++ b/infraform/scenarios/podman/pep8-tests.ifr.j2
@@ -28,3 +28,7 @@ dockerfile: |
  
   RUN alternatives --set python /usr/bin/python3
   RUN dnf install -y python3-devel python2-devel git gcc openssl-devel gettext redhat-rpm-config diffutils
+
+  {% if ('project_name' in vars) and (vars['project_name'] == "tempest_neutron_plugin") %}
+      RUN pip3 install pip -U
+  {% endif %}


### PR DESCRIPTION
We need this patch in order to resolve a problem with our job at [1].
Or maybe you prefer a different approach to resolve this issue. Feel free to ping me and propose a different solution. 

Thanks!

[1] https://rhos-ci-jenkins.lab.eng.tlv2.redhat.com/job/DFG-network-tempest_neutron_plugin-master-component-tests-osp/537/
